### PR TITLE
Added some seed data and fixed shortest path endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Java Development Bootcamp - Teamproject
+
+## Development
+
+To seed some test data into your local mongodb: 
+```
+mongoimport --db=stray --collection=trip --jsonArray seed/trip.json
+```

--- a/backend/src/main/java/com/example/backend/client/OpenServiceApiClient.java
+++ b/backend/src/main/java/com/example/backend/client/OpenServiceApiClient.java
@@ -29,7 +29,7 @@ public class OpenServiceApiClient {
 
         return this.client
                 .post()
-                .uri("/foot-walking")
+                .uri("/matrix/foot-walking")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .bodyValue(matrixServiceRequest)
                 .retrieve()

--- a/backend/src/test/java/com/example/backend/client/OpenServiceApiClientTest.java
+++ b/backend/src/test/java/com/example/backend/client/OpenServiceApiClientTest.java
@@ -84,7 +84,7 @@ class OpenServiceApiClientTest {
         RecordedRequest recordedRequest = this.mockWebServer.takeRequest();
 
         assertEquals(HttpMethod.POST.name(), recordedRequest.getMethod());
-        assertEquals("/foot-walking", recordedRequest.getPath());
+        assertEquals("/matrix/foot-walking", recordedRequest.getPath());
         assertEquals(MediaType.APPLICATION_JSON_VALUE, recordedRequest.getHeader(HttpHeaders.CONTENT_TYPE));
         assertEquals(expectedApiKey, recordedRequest.getHeader(HttpHeaders.AUTHORIZATION));
     }

--- a/seed/trip.json
+++ b/seed/trip.json
@@ -1,0 +1,151 @@
+[{
+  "_id": {
+    "$oid": "63c41b464b11065dcff247e6"
+  },
+  "tripTimeStamp": {
+    "$date": {
+      "$numberLong": "1673796422555"
+    }
+  },
+  "title": "Kneipentour",
+  "locations": [
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e0"
+      },
+      "name": "Laika",
+      "latitude": 52.46944934781305,
+      "longitude": 13.437999741380851
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e1"
+      },
+      "name": "Zum Umsteiger",
+      "latitude": 52.46807309268305,
+      "longitude": 13.431294814396427
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e2"
+      },
+      "name": "Frollein Langner",
+      "latitude": 52.47403190729282,
+      "longitude": 13.425218299052819
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e3"
+      },
+      "name": "Tristeza",
+      "latitude": 52.48668504558828,
+      "longitude": 13.430992443232686
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e4"
+      },
+      "name": "Villa Neukölln",
+      "latitude": 52.48222386801419,
+      "longitude": 13.425091320027116
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e5"
+      },
+      "name": "OYA",
+      "latitude": 52.50104673275016,
+      "longitude": 13.423230048413222
+    }
+  ],
+  "_class": "com.example.backend.model.Trip"
+},{
+  "_id": {
+    "$oid": "63c41d5f4b11065dcff247ef"
+  },
+  "tripTimeStamp": {
+    "$date": {
+      "$numberLong": "1673796959467"
+    }
+  },
+  "title": "Sightseeing Hamburg",
+  "locations": [
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247e7"
+      },
+      "name": "Speicherstadt",
+      "latitude": 53.5462450391128,
+      "longitude": 10.002170963903314
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247e8"
+      },
+      "name": "Alter Elbtunnel",
+      "latitude": 53.54596895295109,
+      "longitude": 9.966619985583302
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247e9"
+      },
+      "name": "Planten un Blomen",
+      "latitude": 53.56236581655875,
+      "longitude": 9.981712705534376
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247ea"
+      },
+      "name": "Rathaus",
+      "latitude": 53.55054591479016,
+      "longitude": 9.99232277023963
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247eb"
+      },
+      "name": "CHOCOVERSUM",
+      "latitude": 53.548048970638284,
+      "longitude": 10.00249175489589
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247ec"
+      },
+      "name": "Elbphilharmonie",
+      "latitude": 53.54150721272578,
+      "longitude": 9.983165043255022
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247ed"
+      },
+      "name": "St. Pauli Landungsbrücken",
+      "latitude": 53.54545205366996,
+      "longitude": 9.966065814419064
+    },
+    {
+      "_id": {
+        "$oid": "63c41d5f4b11065dcff247ee"
+      },
+      "name": "Rote Flora",
+      "latitude": 53.56208826685532,
+      "longitude": 9.96150432218414
+    }
+  ],
+  "_class": "com.example.backend.model.Trip"
+},{
+  "_id": {
+    "$oid": "63c41d7c4b11065dcff247f0"
+  },
+  "tripTimeStamp": {
+    "$date": {
+      "$numberLong": "1673796988834"
+    }
+  },
+  "title": "Trip ohne Locations",
+  "locations": [],
+  "_class": "com.example.backend.model.Trip"
+}]

--- a/seed/trip.json
+++ b/seed/trip.json
@@ -1,63 +1,14 @@
 [{
   "_id": {
-    "$oid": "63c41b464b11065dcff247e6"
+    "$oid": "63c41d7c4b11065dcff247f0"
   },
   "tripTimeStamp": {
     "$date": {
-      "$numberLong": "1673796422555"
+      "$numberLong": "1673796988834"
     }
   },
-  "title": "Kneipentour",
-  "locations": [
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e0"
-      },
-      "name": "Laika",
-      "latitude": 52.46944934781305,
-      "longitude": 13.437999741380851
-    },
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e1"
-      },
-      "name": "Zum Umsteiger",
-      "latitude": 52.46807309268305,
-      "longitude": 13.431294814396427
-    },
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e2"
-      },
-      "name": "Frollein Langner",
-      "latitude": 52.47403190729282,
-      "longitude": 13.425218299052819
-    },
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e3"
-      },
-      "name": "Tristeza",
-      "latitude": 52.48668504558828,
-      "longitude": 13.430992443232686
-    },
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e4"
-      },
-      "name": "Villa Neukölln",
-      "latitude": 52.48222386801419,
-      "longitude": 13.425091320027116
-    },
-    {
-      "_id": {
-        "$oid": "63c41b464b11065dcff247e5"
-      },
-      "name": "OYA",
-      "latitude": 52.50104673275016,
-      "longitude": 13.423230048413222
-    }
-  ],
+  "title": "Trip ohne Locations",
+  "locations": [],
   "_class": "com.example.backend.model.Trip"
 },{
   "_id": {
@@ -138,14 +89,63 @@
   "_class": "com.example.backend.model.Trip"
 },{
   "_id": {
-    "$oid": "63c41d7c4b11065dcff247f0"
+    "$oid": "63c41b464b11065dcff247e6"
   },
   "tripTimeStamp": {
     "$date": {
-      "$numberLong": "1673796988834"
+      "$numberLong": "1673797921554"
     }
   },
-  "title": "Trip ohne Locations",
-  "locations": [],
+  "title": "Kneipentour",
+  "locations": [
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e0"
+      },
+      "name": "Laika",
+      "latitude": 52.46944934781305,
+      "longitude": 13.437999741380851
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e3"
+      },
+      "name": "Tristeza",
+      "latitude": 52.48668504558828,
+      "longitude": 13.430992443232686
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e1"
+      },
+      "name": "Zum Umsteiger",
+      "latitude": 52.46807309268305,
+      "longitude": 13.431294814396427
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e5"
+      },
+      "name": "OYA",
+      "latitude": 52.50104673275016,
+      "longitude": 13.423230048413222
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e4"
+      },
+      "name": "Villa Neukölln",
+      "latitude": 52.48222386801419,
+      "longitude": 13.425091320027116
+    },
+    {
+      "_id": {
+        "$oid": "63c41b464b11065dcff247e2"
+      },
+      "name": "Frollein Langner",
+      "latitude": 52.47403190729282,
+      "longitude": 13.425218299052819
+    }
+  ],
   "_class": "com.example.backend.model.Trip"
 }]


### PR DESCRIPTION
Ich hatte bei der TripDetailPage das Problem, dass ich echte Testdaten brauchte, um den ShortestPath Endpunkt anzufragen. 
Hab meine Mongo Collection mal exportiert und im Projekt abgelegt, so dass man sie recht einfach für Testzwecke wieder importieren kann (siehe README.md).

Außerdem hatten wir beim OpenRouteService noch einen Fehler im Request-Path. Hatte da beim Test nicht richtig aufgepasst, dass wir im Pfad noch `/matrix` brauchen